### PR TITLE
fix: スマホ実機でファーストビューアニメーションが崩れる

### DIFF
--- a/src/View.tsx
+++ b/src/View.tsx
@@ -1,4 +1,4 @@
-import React, { FCX } from 'react'
+import React, { FCX, useState } from 'react'
 import { leftScrollImage, rightScrollImage } from 'consts/carouselImage'
 import { useWatchInnerAspect } from 'hooks/useWatchInnerAspect'
 import { calculateVwBasedOnFigma } from 'utils/figma/calculateSizeBasedOnFigma'
@@ -16,16 +16,17 @@ import { MobileStatusVisualizationModal } from 'components/ui/modal/MobileStatus
 import { Carousel } from 'components/ui/carousel/Carousel'
 import { StartTAoSK } from 'components/ui/startTAoSK/StartTAoSK'
 import { SiteFooter } from 'components/ui/footer/SiteFooter'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 export const View: FCX = ({ className }) => {
   const { innerWidth } = useWatchInnerAspect()
+  const [hasFirstViewAnimationDone, setHasFirstViewAnimationDone] = useState<boolean>(false)
   const breakpoint = 574
 
   return (
     <ViewContainer className={className}>
-      <FirstViewHeader />
-      <StyledFixeContainer>
+      <FirstViewHeader setHasFirstViewAnimationDone={setHasFirstViewAnimationDone} />
+      <StyledFixeContainer hasFirstViewAnimationDone={hasFirstViewAnimationDone}>
         <StyledVideoAreaContainer>
           {innerWidth >= breakpoint ? <VideoArea /> : <MobileVideoArea />}
         </StyledVideoAreaContainer>
@@ -59,7 +60,7 @@ export const View: FCX = ({ className }) => {
 const ViewContainer = styled.div`
   overflow-x: hidden;
 `
-const StyledFixeContainer = styled.div`
+const StyledFixeContainer = styled.div<{ hasFirstViewAnimationDone: boolean }>`
   &::before {
     content: '';
     display: block;
@@ -70,9 +71,18 @@ const StyledFixeContainer = styled.div`
     width: 100%;
     height: 100vh;
     background-repeat: no-repeat;
-    background-position: 50% 100%;
-    background-image: url('/background/plain.jpg');
-    background-size: cover;
+    ${({ hasFirstViewAnimationDone }) =>
+      hasFirstViewAnimationDone
+        ? css`
+            background-position: 50% 100%;
+            background-image: url('/background/plain.jpg');
+            background-size: cover;
+          `
+        : css`
+            background-position: center top;
+            background-image: url('/background/first_view_top.svg');
+            background-size: contain;
+          `}
   }
 `
 const StyledModalContainer = styled.div`

--- a/src/components/ui/header/FirstViewHeader.tsx
+++ b/src/components/ui/header/FirstViewHeader.tsx
@@ -1,14 +1,22 @@
-import React, { FCX } from 'react'
+import React, { useEffect, Dispatch, FCX, SetStateAction } from 'react'
+import { scrollTriggerEndPx } from 'consts/scrollTrigger'
 import { useCalculateFirstViewAnimatedSize } from 'hooks/useCalculateFirstViewAnimatedSize'
 import { useWatchScrollVolume } from 'hooks/useWatchScrollVolume'
 import { useChangeScreenImage } from 'hooks/useChangeScreenImage'
-import { viewBackgroundImage } from 'consts/aspect'
 import styled, { css } from 'styled-components'
 
-export const FirstViewHeader: FCX = ({ className }) => {
+type Props = {
+  setHasFirstViewAnimationDone: Dispatch<SetStateAction<boolean>>
+}
+
+export const FirstViewHeader: FCX<Props> = ({ className, setHasFirstViewAnimationDone }) => {
   const { scrollVolume } = useWatchScrollVolume()
   const { screenImage } = useChangeScreenImage()
   const { innerHeight } = useCalculateFirstViewAnimatedSize()
+
+  useEffect(() => {
+    setHasFirstViewAnimationDone(scrollVolume >= scrollTriggerEndPx)
+  }, [scrollVolume])
 
   return (
     <StyledFirstViewHeaderContainer
@@ -17,9 +25,9 @@ export const FirstViewHeader: FCX = ({ className }) => {
       height={innerHeight}>
       <StyledFirstViewBackground id="first-view__background" />
       <StyledBgWrapper>
-        <StyledTopBg />
-        <StyledFirstViewDummy />
-        <StyledBottomBg />
+        <StyledTopBg id="first-view__top-bg" />
+        <StyledFirstViewDummy id="first-view__background-dummy" />
+        <StyledBottomBg id="first-view__bottom-bg" />
       </StyledBgWrapper>
       <StyledInnerDisplay
         id="first-view__inner-display"
@@ -55,7 +63,7 @@ const StyledBgWrapper = styled.div`
   height: 100%;
 `
 const StyledTopBg = styled.div`
-  flex-grow: 1;
+  top: 10px;
   width: 100vw;
   background-image: url('/background/first_view_top.svg');
   background-size: 100%;
@@ -64,9 +72,6 @@ const StyledTopBg = styled.div`
 `
 const StyledFirstViewDummy = styled.div`
   width: 100vw;
-  height: calc(
-    100vw * ${viewBackgroundImage.HEIGHT} / ${viewBackgroundImage.WIDTH} - 2px
-  ); // 上下の要素に隙間が開いてしまうため-2pxする
   background-color: transparent;
   background-repeat: no-repeat;
 `

--- a/src/components/ui/header/FirstViewHeader.tsx
+++ b/src/components/ui/header/FirstViewHeader.tsx
@@ -8,10 +8,13 @@ import styled, { css } from 'styled-components'
 export const FirstViewHeader: FCX = ({ className }) => {
   const { scrollVolume } = useWatchScrollVolume()
   const { screenImage } = useChangeScreenImage()
-  useCalculateFirstViewAnimatedSize()
+  const { innerHeight } = useCalculateFirstViewAnimatedSize()
 
   return (
-    <StyledFirstViewHeaderContainer id="first-view__container" className={className}>
+    <StyledFirstViewHeaderContainer
+      id="first-view__container"
+      className={className}
+      height={innerHeight}>
       <StyledFirstViewBackground id="first-view__background" />
       <StyledBgWrapper>
         <StyledTopBg />
@@ -27,10 +30,10 @@ export const FirstViewHeader: FCX = ({ className }) => {
   )
 }
 
-const StyledFirstViewHeaderContainer = styled.header`
+const StyledFirstViewHeaderContainer = styled.header<{ height: number }>`
   position: relative;
   width: 100vw;
-  height: 100vh;
+  height: ${({ height }) => height}px;
 `
 const StyledFirstViewBackground = styled.div`
   z-index: ${({ theme }) => theme.Z_INDEX.INDEX_2};

--- a/src/consts/scrollTrigger.ts
+++ b/src/consts/scrollTrigger.ts
@@ -1,0 +1,10 @@
+export const scrollTriggerEndPx = 1000
+
+export const scrollTrigger: gsap.AnimationVars['scrollTrigger'] = {
+  trigger: '#first-view__container',
+  start: 'top',
+  end: `${scrollTriggerEndPx}px`,
+  markers: true,
+  pin: true,
+  scrub: true,
+} as const

--- a/src/hooks/useCalculateFirstViewAnimatedSize.ts
+++ b/src/hooks/useCalculateFirstViewAnimatedSize.ts
@@ -4,10 +4,12 @@ import ScrollTrigger from 'gsap/ScrollTrigger'
 import { useWatchInnerAspect } from 'hooks/useWatchInnerAspect'
 import { useCalculateInnerPcStyle } from 'hooks/useCalculateInnerPcStyle'
 
+type UseCalculateFirstViewAnimatedSizeReturn = { innerHeight: number }
+
 /**
  * ファーストビューでスクロールした時に画面内のPCがピッタリ実際の画面に収まるような拡大率・位置を計算し、アニメーションを付与する
  */
-export const useCalculateFirstViewAnimatedSize = (): void => {
+export const useCalculateFirstViewAnimatedSize = (): UseCalculateFirstViewAnimatedSizeReturn => {
   const { innerWidth, innerHeight } = useWatchInnerAspect()
   const windowAspectRatio = useMemo<number>(
     () => innerHeight / innerWidth,
@@ -152,4 +154,6 @@ export const useCalculateFirstViewAnimatedSize = (): void => {
     }
     firstViewAnimation()
   }, [firstViewAnimation])
+
+  return { innerHeight }
 }

--- a/src/hooks/useCalculateFirstViewAnimatedSize.ts
+++ b/src/hooks/useCalculateFirstViewAnimatedSize.ts
@@ -1,8 +1,10 @@
 import { useRef, useMemo, useCallback, useEffect } from 'react'
 import gsap from 'gsap'
 import ScrollTrigger from 'gsap/ScrollTrigger'
+import { scrollTrigger } from 'consts/scrollTrigger'
 import { useWatchInnerAspect } from 'hooks/useWatchInnerAspect'
 import { useCalculateInnerPcStyle } from 'hooks/useCalculateInnerPcStyle'
+import { getViewBgAspectRatio } from 'utils/getFirstViewSizeRatio'
 
 type UseCalculateFirstViewAnimatedSizeReturn = { innerHeight: number }
 
@@ -88,6 +90,7 @@ export const useCalculateFirstViewAnimatedSize = (): UseCalculateFirstViewAnimat
     for (let i = 0; i < allTriggers.length; i++) {
       allTriggers[i].kill(true)
     }
+    const viewBgAspectRatio = getViewBgAspectRatio()
 
     // それぞれのCSSプロパティの値は、アニメーション前と後で単位を合わせないと予期したスタイルにならない
     gsap.fromTo(
@@ -97,15 +100,7 @@ export const useCalculateFirstViewAnimatedSize = (): UseCalculateFirstViewAnimat
         backgroundPosition: `0px ${initialViewBgPositionTop}px`,
       },
       {
-        scrollTrigger: {
-          trigger: '#first-view__container',
-          start: 'top',
-          end: '1000px',
-          markers: true,
-          pin: true,
-          scrub: true,
-        },
-
+        scrollTrigger,
         backgroundSize: `${animatedBgSizeRatio * 100}%`,
         backgroundPosition: `${innerPcAnimatedWidthPosition}px ${innerPcAnimatedHeightPosition}px`,
       },
@@ -119,18 +114,48 @@ export const useCalculateFirstViewAnimatedSize = (): UseCalculateFirstViewAnimat
         height: `${innerPcStyle.height}px`,
       },
       {
-        scrollTrigger: {
-          trigger: '#first-view__container',
-          start: 'top',
-          end: '1000px',
-          markers: true,
-          pin: true,
-          scrub: true,
-        },
+        scrollTrigger,
         top: `${innerPcAnimatedTop}px`,
         left: `${innerPcAnimatedLeft}px`,
         width: `${innerPcStyle.width * animatedBgSizeRatio}px`,
         height: `${innerPcStyle.height * animatedBgSizeRatio}px`,
+      },
+    )
+    gsap.fromTo(
+      '#first-view__top-bg',
+      // 下の要素に隙間が開いてしまうため+10する
+      {
+        backgroundSize: '100%',
+        height: `${initialViewBgPositionTop + 10}px`,
+      },
+      {
+        scrollTrigger,
+        backgroundSize: `${animatedBgSizeRatio * 100}%`,
+        height: `${innerPcAnimatedHeightPosition + 10}px`,
+      },
+    )
+    gsap.fromTo(
+      '#first-view__background-dummy',
+      // 上下の要素に隙間が開いてしまうため-20pxする
+      { height: `calc(100vw * ${viewBgAspectRatio} - 20px)` },
+      {
+        scrollTrigger,
+        height: `calc(100vw * ${viewBgAspectRatio * animatedBgSizeRatio} -20px)`,
+      },
+    )
+    gsap.fromTo(
+      '#first-view__bottom-bg',
+      // 上の要素に隙間が開いてしまうため+10pxする
+      {
+        top: '-20px',
+        backgroundSize: '100%',
+        height: `${initialViewBgPositionTop + 10}px`,
+      },
+      {
+        scrollTrigger,
+        top: '-20px',
+        backgroundSize: `${animatedBgSizeRatio * 100}%`,
+        height: `${innerPcAnimatedHeightPosition + 10}px`,
       },
     )
   }, [

--- a/src/hooks/useCalculateFirstViewAnimatedSize.ts
+++ b/src/hooks/useCalculateFirstViewAnimatedSize.ts
@@ -82,6 +82,11 @@ export const useCalculateFirstViewAnimatedSize = (): void => {
   const firstViewAnimation = useCallback(() => {
     if (!innerWidth || !innerHeight) return
 
+    const allTriggers = ScrollTrigger.getAll()
+    for (let i = 0; i < allTriggers.length; i++) {
+      allTriggers[i].kill(true)
+    }
+
     // それぞれのCSSプロパティの値は、アニメーション前と後で単位を合わせないと予期したスタイルにならない
     gsap.fromTo(
       '#first-view__background',

--- a/src/hooks/useCalculateFirstViewAnimatedSize.ts
+++ b/src/hooks/useCalculateFirstViewAnimatedSize.ts
@@ -24,7 +24,7 @@ export const useCalculateFirstViewAnimatedSize = (): void => {
     } else {
       return tailedHeight / 2
     }
-  }, [innerHeight, innerPcStyle.height, tailedHeight])
+  }, [isFitIntoWindow, tailedHeight])
 
   const animatedBgSizeRatio = useMemo<number>(() => {
     if (isFitIntoWindow) {
@@ -32,7 +32,7 @@ export const useCalculateFirstViewAnimatedSize = (): void => {
     } else {
       return innerHeight / innerPcStyle.height
     }
-  }, [innerWidth, innerPcStyle.width])
+  }, [isFitIntoWindow, innerWidth, innerHeight, innerPcStyle.width, innerPcStyle.height])
 
   const tailedInnerPcTop = useMemo<number>(
     () => (innerPcStyle.height - innerPcStyle.width * windowAspectRatio) / 2,
@@ -41,7 +41,7 @@ export const useCalculateFirstViewAnimatedSize = (): void => {
 
   const tailedInnerPcLeft = useMemo<number>(
     () => (innerPcStyle.width - innerPcStyle.height * (1 / windowAspectRatio)) / 2,
-    [innerPcStyle.width, innerPcStyle.height],
+    [innerPcStyle.width, innerPcStyle.height, windowAspectRatio],
   )
 
   const innerPcAnimatedWidthPosition = useMemo<number>(() => {
@@ -50,7 +50,7 @@ export const useCalculateFirstViewAnimatedSize = (): void => {
     } else {
       return -(innerPcStyle.left + tailedInnerPcLeft) * animatedBgSizeRatio
     }
-  }, [tailedInnerPcLeft, innerPcStyle.left, animatedBgSizeRatio])
+  }, [isFitIntoWindow, tailedInnerPcLeft, innerPcStyle.left, animatedBgSizeRatio])
 
   const innerPcAnimatedHeightPosition = useMemo<number>(() => {
     if (isFitIntoWindow) {
@@ -59,7 +59,7 @@ export const useCalculateFirstViewAnimatedSize = (): void => {
     } else {
       return -(innerPcStyle.top - tailedHeight / 2) * animatedBgSizeRatio
     }
-  }, [tailedInnerPcTop, animatedBgSizeRatio])
+  }, [isFitIntoWindow, innerPcStyle.top, tailedHeight, tailedInnerPcTop, animatedBgSizeRatio])
 
   const innerPcAnimatedTop = useMemo<number>(() => {
     if (isFitIntoWindow) {
@@ -67,7 +67,7 @@ export const useCalculateFirstViewAnimatedSize = (): void => {
     } else {
       return 0
     }
-  }, [tailedInnerPcTop])
+  }, [isFitIntoWindow, tailedInnerPcTop, animatedBgSizeRatio])
 
   const innerPcAnimatedLeft = useMemo<number>(() => {
     if (isFitIntoWindow) {
@@ -75,7 +75,7 @@ export const useCalculateFirstViewAnimatedSize = (): void => {
     } else {
       return -(tailedInnerPcLeft * animatedBgSizeRatio)
     }
-  }, [innerPcStyle.left, tailedInnerPcTop])
+  }, [isFitIntoWindow, innerPcStyle.left, tailedInnerPcTop, animatedBgSizeRatio])
 
   const isRegistered = useRef<boolean>(false)
 


### PR DESCRIPTION
## 実装の概要
- 画面のheightに変更があったときにアニメーションを再計算するようにした
  - 前回まではuseEffectの第二引数に依存関係が足りなかったためスマホが崩れていた
- アニメーション再計算時に既存のスクロールアニメーションを削除するようにした
  -`allTriggers[i].kill(true)`
- iOS Safariがツールバー分のheightでvhが期待通りにならない問題に対応するために`window.innerHeight`をpropsとして渡すようにした
  - 下記リンクのやり方を試したが、ツールバー表示 -> 非表示の切り替えをしたときにheightが再計算されずスタイルが崩れたので、止むを得ず上記の方法を使った
  - [これからはこの実装がオススメ！ブラウザの高さいっぱい、iOSでアドレスバーがあっても高さいっぱいに表示するCSSのテクニック | コリス](https://coliss.com/articles/build-websites/operation/css/css-cover-the-entire-height-of-the-screen.html)
- PC画像の上下の余白のグラデーションがもっと滑らかになるようにgsapアニメーションでheightを変更するようにした
- Webページ全体をバウンドさせた時に背景画像が見えてしまう問題を修正

https://user-images.githubusercontent.com/47961006/147791287-d3a64d82-42cf-4f87-ab3a-41d3f0f45b49.mov

https://user-images.githubusercontent.com/47961006/147791282-6d80cdc1-8b68-432c-92af-0636c163dc9c.mov

<!-- 概要を入力 -->

Closes #11 <!-- issueをcloseさせたい & trelloのタスクを完了に移動したい場合 -->

## 目的
スマホサイズでもスタイルを崩すことなくファーストビューアニメーションを実行させる

## レビューして欲しいところ

## 不安に思っていること
- スクロールすると画面が若干チラつく
  - 原因
    - heightの変化でアニメーションを再計算していること
    - gsapのスクロールアニメーションを使うと、スマホで勢いをつけてスクロールすると特定のスクロール位置でピタッと止まってしまうらしい
      - スクロールアニメーションを終えた後、特徴セクションからファーストビューセクションに一気に戻ろとすると、その境目のところでピタッと止まってしまう。これにより、カクついてるように感じてしまう
      - 修正可能かもしれないがよくわからないのであまりやりたくない

https://user-images.githubusercontent.com/47961006/147791513-43ff2573-71f2-4e78-a3e5-5453711dbcc0.mov

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク
- メインに戻ってプロジェクト編集/削除モーダル
- #12

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
