### PR TITLE
fix: 開発モードのみgsapのmarkerを出す

### DIFF
--- a/src/consts/scrollTrigger.ts
+++ b/src/consts/scrollTrigger.ts
@@ -4,7 +4,7 @@ export const scrollTrigger: gsap.AnimationVars['scrollTrigger'] = {
   trigger: '#first-view__container',
   start: 'top',
   end: `${scrollTriggerEndPx}px`,
-  markers: true,
+  markers: process.env.NODE_ENV !== 'production',
   pin: true,
   scrub: true,
 } as const


### PR DESCRIPTION
## 実装の概要
開発モードのみgsapのmarkerを出す
buildしたらmarkerを消す

## 目的

## レビューして欲しいところ

## 不安に思っていること

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
