### PR TITLE
fix: iOS Safariでアニメーションが大きく崩れてしまう問題を修正

### DIFF
--- a/src/components/ui/header/FirstViewHeader.tsx
+++ b/src/components/ui/header/FirstViewHeader.tsx
@@ -79,44 +79,46 @@ export const FirstViewHeader: FCX<Props> = ({
       </StyledFirstViewHeaderContainer>
 
       <StyledLogoAndContentsContainer height={innerHeight}>
-        <StyledLogoAndContents id="first-view__logo-and-contents">
-          <StyledLogo src="/screen/top-logo.webp" alt="TAoSK" />
+        <StyledLogoAndContentsWrapper id="first-view__logo-and-contents-wrapper">
+          <StyledLogoAndContents id="first-view__logo-and-contents">
+            <StyledLogo src="/screen/top-logo.webp" alt="TAoSK" />
 
-          <StyledContentsWrapper>
-            <StyledContents>
-              <StyledContent
-                hasAnimatedFirstBlur={hasAnimatedFirstBlur}
-                isHovered={nowHovered === 'aboutTAoSK'}
-                onClick={() => handleScrollTo(scrollToAboutTaosk)}
-                onMouseEnter={() => handleNowHovered('aboutTAoSK')}>
-                <StyledContentTextImg
-                  alt="TAoSKとは"
-                  src={`/contents/${contentsPath}/about-taosk.svg`}
-                />
-              </StyledContent>
-              <StyledContent
-                hasAnimatedFirstBlur={hasAnimatedFirstBlur}
-                isHovered={nowHovered === 'concept'}
-                onClick={() => handleScrollTo(scrollToConcept)}
-                onMouseEnter={() => handleNowHovered('concept')}>
-                <StyledContentTextImg
-                  alt="とくちょう"
-                  src={`/contents/${contentsPath}/concept.svg`}
-                />
-              </StyledContent>
-              <StyledContent
-                hasAnimatedFirstBlur={hasAnimatedFirstBlur}
-                isHovered={nowHovered === 'start'}
-                onClick={() => handleScrollTo(scrollToStartTaosk)}
-                onMouseEnter={() => handleNowHovered('start')}>
-                <StyledContentTextImg
-                  alt="はじめよう"
-                  src={`/contents/${contentsPath}/lets-start.svg`}
-                />
-              </StyledContent>
-            </StyledContents>
-          </StyledContentsWrapper>
-        </StyledLogoAndContents>
+            <StyledContentsWrapper>
+              <StyledContents>
+                <StyledContent
+                  hasAnimatedFirstBlur={hasAnimatedFirstBlur}
+                  isHovered={nowHovered === 'aboutTAoSK'}
+                  onClick={() => handleScrollTo(scrollToAboutTaosk)}
+                  onMouseEnter={() => handleNowHovered('aboutTAoSK')}>
+                  <StyledContentTextImg
+                    alt="TAoSKとは"
+                    src={`/contents/${contentsPath}/about-taosk.svg`}
+                  />
+                </StyledContent>
+                <StyledContent
+                  hasAnimatedFirstBlur={hasAnimatedFirstBlur}
+                  isHovered={nowHovered === 'concept'}
+                  onClick={() => handleScrollTo(scrollToConcept)}
+                  onMouseEnter={() => handleNowHovered('concept')}>
+                  <StyledContentTextImg
+                    alt="とくちょう"
+                    src={`/contents/${contentsPath}/concept.svg`}
+                  />
+                </StyledContent>
+                <StyledContent
+                  hasAnimatedFirstBlur={hasAnimatedFirstBlur}
+                  isHovered={nowHovered === 'start'}
+                  onClick={() => handleScrollTo(scrollToStartTaosk)}
+                  onMouseEnter={() => handleNowHovered('start')}>
+                  <StyledContentTextImg
+                    alt="はじめよう"
+                    src={`/contents/${contentsPath}/lets-start.svg`}
+                  />
+                </StyledContent>
+              </StyledContents>
+            </StyledContentsWrapper>
+          </StyledLogoAndContents>
+        </StyledLogoAndContentsWrapper>
       </StyledLogoAndContentsContainer>
 
       {/* ファーストビューはposition: fixedで固定されているので、同じ高さ分dummyを設置してスクロールですぐに特徴セクションが現れないようにする */}
@@ -203,6 +205,9 @@ const StyledLogoAndContentsContainer = styled.div<{ height: number }>`
   position: fixed;
   width: 100vw;
   height: ${({ height }) => height}px;
+`
+const StyledLogoAndContentsWrapper = styled.div`
+  position: relative;
 `
 const StyledLogoAndContents = styled.div`
   position: relative;

--- a/src/components/ui/header/FirstViewHeader.tsx
+++ b/src/components/ui/header/FirstViewHeader.tsx
@@ -66,8 +66,8 @@ export const FirstViewHeader: FCX<Props> = ({
   }, [firstViewAnimationDummyHeight, scrollVolume])
 
   return (
-    <StyledAllWrapper className={className}>
-      <StyledFirstViewHeaderContainer id="first-view__container" height={innerHeight}>
+    <StyledAllWrapper id="first-view__container" className={className}>
+      <StyledFirstViewHeaderContainer height={innerHeight}>
         <StyledFirstViewBackground id="first-view__background" />
         <StyledBgWrapper>
           <StyledTopBg id="first-view__top-bg" />

--- a/src/consts/scrollTrigger.ts
+++ b/src/consts/scrollTrigger.ts
@@ -18,6 +18,7 @@ export const dotBlurScrollTrigger: gsap.AnimationVars['scrollTrigger'] = {
   end: 'bottom bottom',
   // markers:  process.env.NODE_ENV !== 'production',
   scrub: true,
+  invalidateOnRefresh: true,
 } as const
 
 export const illustBlurScrollTrigger: gsap.AnimationVars['scrollTrigger'] = {
@@ -26,6 +27,7 @@ export const illustBlurScrollTrigger: gsap.AnimationVars['scrollTrigger'] = {
   end: `bottom-=${ILLUST_BLUR_SCROLL_PX / 2}px bottom`,
   // markers:  process.env.NODE_ENV !== 'production',
   scrub: true,
+  invalidateOnRefresh: true,
 } as const
 
 export const makeDarkerScrollTrigger: gsap.AnimationVars['scrollTrigger'] = {

--- a/src/consts/scrollTrigger.ts
+++ b/src/consts/scrollTrigger.ts
@@ -4,7 +4,7 @@ export const ILLUST_BLUR_SCROLL_PX = 1000
 export const MAKE_DARKER_SCROLL_PX = 1000
 export const MOVE_AS_SCROLL_SCROLL_PX = 2500
 
-export const scrollTrigger: gsap.AnimationVars['scrollTrigger'] = {
+export const firstViewScrollTrigger: gsap.AnimationVars['scrollTrigger'] = {
   trigger: '#first-view__container',
   start: 'top',
   end: `${FIRST_VIEW_SCROLL_TRIGGER_END_PX}px`,

--- a/src/hooks/useAddFirstViewAnimation.ts
+++ b/src/hooks/useAddFirstViewAnimation.ts
@@ -27,6 +27,7 @@ export const useAddFirstViewAnimation = (): UseAddFirstViewAnimationReturn => {
     useFirstViewBackgroundAnimation({ ...innerPcAnimationVariables })
   const { addLogoAndContentsAnimation, addMovingLogoAndContentsAsScrollAnimation } =
     useFirstViewLogoAndContentsAnimation({
+      innerWidth,
       ...innerPcAnimationVariables,
     })
 

--- a/src/hooks/useFirstViewBackgroundAnimation.ts
+++ b/src/hooks/useFirstViewBackgroundAnimation.ts
@@ -1,6 +1,6 @@
 import { useMemo, useCallback } from 'react'
 import gsap from 'gsap'
-import { scrollTrigger } from 'consts/scrollTrigger'
+import { firstViewScrollTrigger } from 'consts/scrollTrigger'
 import { getViewBgAspectRatio } from 'utils/getFirstViewSizeRatio'
 
 type UseFirstViewBackgroundAnimationArg = {
@@ -67,7 +67,7 @@ export const useFirstViewBackgroundAnimation: UseFirstViewBackgroundAnimation = 
         backgroundPosition: `0px ${initialViewBgPositionTop}px`,
       },
       {
-        scrollTrigger,
+        scrollTrigger: firstViewScrollTrigger,
         backgroundSize: `${animatedBgSizeRatio * 100}%`,
         backgroundPosition: `${innerPcAnimatedXPosition}px ${innerPcAnimatedYPosition}px`,
       },
@@ -89,7 +89,7 @@ export const useFirstViewBackgroundAnimation: UseFirstViewBackgroundAnimation = 
         height: `${initialViewBgPositionTop + 10}px`,
       },
       {
-        scrollTrigger,
+        scrollTrigger: firstViewScrollTrigger,
         backgroundSize: `${animatedBgSizeRatio * 100}%`,
         height: `${innerPcAnimatedYPosition + 10}px`,
       },
@@ -99,7 +99,7 @@ export const useFirstViewBackgroundAnimation: UseFirstViewBackgroundAnimation = 
       // 上下の要素に隙間が開いてしまうため-20pxする
       { height: `calc(100vw * ${viewBgAspectRatio} - 20px)` },
       {
-        scrollTrigger,
+        scrollTrigger: firstViewScrollTrigger,
         height: `calc(100vw * ${viewBgAspectRatio * animatedBgSizeRatio} -20px)`,
       },
     )
@@ -112,7 +112,7 @@ export const useFirstViewBackgroundAnimation: UseFirstViewBackgroundAnimation = 
         height: `${initialViewBgPositionTop + 10}px`,
       },
       {
-        scrollTrigger,
+        scrollTrigger: firstViewScrollTrigger,
         top: '-20px',
         backgroundSize: `${animatedBgSizeRatio * 100}%`,
         height: `${innerPcAnimatedYPosition + 10}px`,

--- a/src/hooks/useFirstViewInnerPcAnimation.ts
+++ b/src/hooks/useFirstViewInnerPcAnimation.ts
@@ -7,7 +7,7 @@ import {
   getViewBgAspectRatio,
 } from 'utils/getFirstViewSizeRatio'
 import gsap from 'gsap'
-import { scrollTrigger } from 'consts/scrollTrigger'
+import { firstViewScrollTrigger } from 'consts/scrollTrigger'
 
 type UseFirstViewInnerPcAnimation = {
   addInnerPcAnimation: () => void
@@ -112,7 +112,7 @@ export const useFirstViewInnerPcAnimation = (
         height: `${height}px`,
       },
       {
-        scrollTrigger,
+        scrollTrigger: firstViewScrollTrigger,
         top: `${innerPcAnimatedTop}px`,
         left: `${innerPcAnimatedLeft}px`,
         width: `${width * animatedBgSizeRatio}px`,

--- a/src/hooks/useFirstViewLogoAndContentsAnimation.ts
+++ b/src/hooks/useFirstViewLogoAndContentsAnimation.ts
@@ -1,6 +1,6 @@
 import { useMemo, useCallback } from 'react'
 import gsap from 'gsap'
-import { scrollTrigger } from 'consts/scrollTrigger'
+import { firstViewScrollTrigger } from 'consts/scrollTrigger'
 import { moveAsScrollScrollTrigger, MOVE_AS_SCROLL_SCROLL_PX } from 'consts/scrollTrigger'
 import {
   getLogoAndContentsPerInnerPcWidthRatio,
@@ -87,7 +87,7 @@ export const useFirstViewLogoAndContentsAnimation: UseFirstViewLogoAndContentsAn
         height: `min(${height}px, ${animatedMaxHeight}px)`,
       },
       {
-        scrollTrigger,
+        scrollTrigger: firstViewScrollTrigger,
         top: `max(${animatedTop}px, 0px)`,
         left: `max(${animatedLeft}px, 0px)`,
         width: `min(${animatedWidth}px, ${animatedMaxWidth}px)`,

--- a/src/hooks/useFirstViewLogoAndContentsAnimation.ts
+++ b/src/hooks/useFirstViewLogoAndContentsAnimation.ts
@@ -114,9 +114,9 @@ export const useFirstViewLogoAndContentsAnimation: UseFirstViewLogoAndContentsAn
 
   const addMovingLogoAndContentsAsScrollAnimation = useCallback(() => {
     gsap.fromTo(
-      '#first-view__logo-and-contents',
+      '#first-view__logo-and-contents-wrapper',
       {
-        top: `${innerPcAnimatedTop + animatedTop}px`,
+        top: '0px',
       },
       {
         scrollTrigger: moveAsScrollScrollTrigger,
@@ -124,7 +124,7 @@ export const useFirstViewLogoAndContentsAnimation: UseFirstViewLogoAndContentsAn
         ease: 'none',
       },
     )
-  }, [innerPcAnimatedTop, animatedTop])
+  }, [animatedTop])
 
   return { addLogoAndContentsAnimation, addMovingLogoAndContentsAsScrollAnimation }
 }

--- a/src/utils/scrollAnimation.ts
+++ b/src/utils/scrollAnimation.ts
@@ -4,6 +4,8 @@ import {
   dotBlurScrollTrigger,
   illustBlurScrollTrigger,
   makeDarkerScrollTrigger,
+  FIRST_VIEW_SCROLL_TRIGGER_END_PX,
+  DOT_BLUR_SCROLL_PX,
 } from 'consts/scrollTrigger'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
 import { theme } from 'styles/global/theme'
@@ -18,7 +20,16 @@ export const resetAllScrollAnimation = () => {
 
 /** ファーストビューでスクロールで徐々にブラーがかかるアニメーションを付与する */
 export const addBlurAnimation = () => {
-  // この順番でアニメーションを付与しないと期待通りのアニメーションにならない
+  // 画面のリサイズが行われた際に、意図していない箇所でブラーがかかってしまうのを防ぐ
+  const filterBlurAtDotBlurScrollTrigger = (): string => {
+    const blurScrollPosition = FIRST_VIEW_SCROLL_TRIGGER_END_PX + DOT_BLUR_SCROLL_PX
+    if (window.scrollY >= blurScrollPosition) {
+      return 'blur(0px)'
+    } else {
+      return 'blur(15px)'
+    }
+  }
+
   gsap.fromTo(
     '#first-view__inner-display',
     {
@@ -36,7 +47,7 @@ export const addBlurAnimation = () => {
     { filter: 'blur(0px)' },
     {
       scrollTrigger: dotBlurScrollTrigger,
-      filter: 'blur(15px)',
+      filter: filterBlurAtDotBlurScrollTrigger,
     },
   )
   gsap.fromTo(
@@ -54,7 +65,7 @@ export const addBlurAnimation = () => {
     { filter: 'blur(0px)' },
     {
       scrollTrigger: dotBlurScrollTrigger,
-      filter: 'blur(15px)',
+      filter: filterBlurAtDotBlurScrollTrigger,
     },
   )
 }


### PR DESCRIPTION
## 実装の概要
- iOSの上下のスクロールによりheightが変わることでアニメーションの再計算が起き、scrollTriggerに設定している要素の位置が想定とはずれているためにスタイル崩れが起きていた
  - scrollTriggerを変更することで解決
- 途中でブラーがかかりっぱなしになってしまう問題については、filterにfunctionを渡すことで条件分岐させ修正した

<!-- 概要を入力 -->

Closes #12 <!-- issueをcloseさせたい & trelloのタスクを完了に移動したい場合 -->

## 目的
iOS Safariでファーストビューのアニメーションが崩れる問題の修正

## レビューして欲しいところ

## 不安に思っていること
- iOS Safariで、background-imageの変更が起きた際に画像がチラついてしまう
  - 下記urlの方法も試したところ、その部分に関しては改善されたもののgsapとの兼ね合いのせいか、セクションのアニメーションが発生するたびにちらつきが発生するなど、挙動が悪化したためそのままにした
  - [もうちらつきなんて怖くない！マウスオーバーでbackground-imageを切り替える方法 | Logical Studio Blog](https://logical-studio.com/develop/web/20200703-background-changed-without-flicker/)
- この後特徴セクションのモーダルのアニメーションの改善に着手しようと思っているが、上記の挙動の修正と、アニメーション改善のどちらが優先度高いかを知りたい

https://user-images.githubusercontent.com/47961006/148628846-52c2fe9f-f8a8-46d5-8744-43edf78f5014.mov

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
