### PR TITLE
add: 特徴セクションの文字/画像にアニメーションを付与

### DIFF
--- a/src/components/ui/footer/SiteFooter.tsx
+++ b/src/components/ui/footer/SiteFooter.tsx
@@ -57,7 +57,7 @@ const FlexContainer = styled.div`
   display: flex;
   align-items: center;
   ${mediaQuery.sm`
-     display: block;
+    display: block;
   `}
 `
 const StyledFooter = styled.footer`
@@ -65,42 +65,41 @@ const StyledFooter = styled.footer`
   height: ${calculateVwBasedOnFigma(120)};
   background: ${({ theme }) => theme.COLORS.BACKGROUND.MINE_SHAFT};
   ${mediaQuery.md`
-     height: ${calculateVwBasedOnFigma(160)};
+    height: ${calculateVwBasedOnFigma(160)};
   `}
   ${mediaQuery.sm`
-     height: ${calculateVwBasedOnFigma(700)};
+    height: ${calculateVwBasedOnFigma(700)};
   `}
 `
 const StyledFooterHead = styled(FlexContainer)`
   justify-content: space-between;
   padding: ${calculateVwBasedOnFigma(16)} ${calculateVwBasedOnFigma(64)};
   ${mediaQuery.sm`
-     padding: 20px 55px;
-     padding: ${calculateVwBasedOnFigma(80)} ${calculateVwBasedOnFigma(150)};
+    padding: ${calculateVwBasedOnFigma(80)} ${calculateVwBasedOnFigma(150)};
   `}
 `
 const StyledLogoContainer = styled(FlexContainer)`
   gap: ${calculateVwBasedOnFigma(40)};
   ${mediaQuery.sm`
-     display: flex;
-     gap: ${calculateVwBasedOnFigma(40)};
-     justify-content: center;
+    display: flex;
+    gap: ${calculateVwBasedOnFigma(40)};
+    justify-content: center;
   `}
 `
 const StyledSNSContainer = styled(FlexContainer)`
   gap: ${calculateVwBasedOnFigma(40)};
   ${mediaQuery.sm`
-     display: flex;
-     flex-direction: row-reverse;
-     gap: ${calculateVwBasedOnFigma(80)};
-     justify-content: center;
-     margin-top: ${calculateVwBasedOnFigma(100)};
+    display: flex;
+    flex-direction: row-reverse;
+    gap: ${calculateVwBasedOnFigma(80)};
+    justify-content: center;
+    margin-top: ${calculateVwBasedOnFigma(100)};
   `}
 `
 const StyledTAoSK = styled.img`
   width: ${calculateVwBasedOnFigma(117)};
   ${mediaQuery.sm`
-     width: ${calculateVwBasedOnFigma(440)};
+    width: ${calculateVwBasedOnFigma(440)};
   `}
 `
 const StyledHalTokyo = styled.img`
@@ -112,7 +111,7 @@ const StyledHalTokyo = styled.img`
 const StyledSNS = styled.img`
   width: ${calculateVwBasedOnFigma(30)};
   ${mediaQuery.sm`
-     width: ${calculateVwBasedOnFigma(110)};
+    width: ${calculateVwBasedOnFigma(110)};
   `}
 `
 const StyledPlay = styled.p`
@@ -120,8 +119,8 @@ const StyledPlay = styled.p`
   font-weight: ${({ theme }) => theme.FONT_WEIGHTS.BOLD};
   color: ${({ theme }) => theme.COLORS.TEXT.GRAY};
   ${mediaQuery.sm`
-     font-size: ${calculateVwBasedOnFigma(50)};
-     padding-bottom: ${calculateVwBasedOnFigma(16)};
+    font-size: ${calculateVwBasedOnFigma(50)};
+    padding-bottom: ${calculateVwBasedOnFigma(16)};
   `}
 `
 const StyledBorder = styled.div`

--- a/src/components/ui/label/Feature.tsx
+++ b/src/components/ui/label/Feature.tsx
@@ -1,5 +1,8 @@
 import React, { FCX } from 'react'
-import { calculateMinSizeBasedOnFigma } from 'utils/figma/calculateSizeBasedOnFigma'
+import {
+  calculateMinSizeBasedOnFigma,
+  calculateSmMinSizeBasedOnFigma,
+} from 'utils/figma/calculateSizeBasedOnFigma'
 import { mediaQuery } from 'utils/response/mediaQuery'
 import styled from 'styled-components'
 
@@ -8,18 +11,19 @@ type Props = {}
 export const Feature: FCX<Props> = ({ className }) => {
   return (
     <StyledContainer className={className}>
-      <StyledFeatureImage src="/feature.png" alt="feature" loading="lazy" />
+      <StyledFeatureImage src="/feature.png" alt="feature" />
     </StyledContainer>
   )
 }
 
 const StyledContainer = styled.div`
+  position: relative;
   text-align: center;
 `
 const StyledFeatureImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(428)};
   margin: 0 auto;
   ${mediaQuery.sm`
-    width: ${calculateMinSizeBasedOnFigma(266)};
+    width: ${calculateSmMinSizeBasedOnFigma(266)};
   `}
 `

--- a/src/components/ui/label/Feature.tsx
+++ b/src/components/ui/label/Feature.tsx
@@ -1,5 +1,5 @@
 import React, { FCX } from 'react'
-import { calculateVwBasedOnFigma } from 'utils/figma/calculateSizeBasedOnFigma'
+import { calculateMinSizeBasedOnFigma } from 'utils/figma/calculateSizeBasedOnFigma'
 import { mediaQuery } from 'utils/response/mediaQuery'
 import styled from 'styled-components'
 
@@ -17,9 +17,9 @@ const StyledContainer = styled.div`
   text-align: center;
 `
 const StyledFeatureImage = styled.img`
-  width: ${calculateVwBasedOnFigma(428)};
+  width: ${calculateMinSizeBasedOnFigma(428)};
   margin: 0 auto;
   ${mediaQuery.sm`
-    width: 266px;
+    width: ${calculateMinSizeBasedOnFigma(266)};
   `}
 `

--- a/src/components/ui/label/Feature.tsx
+++ b/src/components/ui/label/Feature.tsx
@@ -20,6 +20,6 @@ const StyledFeatureImage = styled.img`
   width: ${calculateVwBasedOnFigma(428)};
   margin: 0 auto;
   ${mediaQuery.sm`
-     width: 266px;
+    width: 266px;
   `}
 `

--- a/src/components/ui/modal/HPandMPVisualizationModal.tsx
+++ b/src/components/ui/modal/HPandMPVisualizationModal.tsx
@@ -3,6 +3,7 @@ import { Modal } from 'components/ui/modal/Modal'
 import { ROOT_MARGIN } from 'consts/rootMargin'
 import { useInView } from 'react-intersection-observer'
 import { calculateMinSizeBasedOnFigma } from 'utils/figma/calculateSizeBasedOnFigma'
+import { animation } from 'styles/animation/modalAnimation'
 import styled from 'styled-components'
 
 type Props = {}
@@ -19,7 +20,7 @@ export const HPandMPVisualizationModal: FCX<Props> = ({ className }) => {
         <Modal title="HP,MPの見える化">
           <StyledWrap>
             <div>
-              <StyledTitleImage src="/modal/hp_mp_title.png" alt="HP,MPを脳波でリアルタイム解析" />
+              <StyledTitleImage src="/modal/hp_mp_title.png" alt="HP,MPを脳波でリアルタイム解析!" />
             </div>
             <StyledFlexContainer>
               <div>
@@ -35,7 +36,7 @@ export const HPandMPVisualizationModal: FCX<Props> = ({ className }) => {
             <StyledTextImageContainer>
               <StyledTextImage
                 src="/modal/hp_mp_text.png"
-                alt="顔認証で仲間の名前,役職,HP,MPを表示"
+                alt="顔認証で仲間の名前,役職,HP,MPを表示!"
               />
             </StyledTextImageContainer>
             <StyledEggContainer>
@@ -64,15 +65,19 @@ const StyledFlexContainer = styled.div`
 const StyledTitleImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(607)};
   padding-bottom: ${calculateMinSizeBasedOnFigma(16)};
+  ${animation.firstShownChildren}
 `
 const StyledInstalledUserImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(394)};
+  ${animation.firstShownChildren}
 `
 const StyledMindWaveImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(220)};
+  ${animation.firstShownChildren}
 `
 const StyledKurauchiContainer = styled.div`
   transform: translateY(-41%);
+  ${animation.secondShownChildren}
 `
 const StyledKurauchiImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(316)};
@@ -81,6 +86,7 @@ const StyledTextImageContainer = styled.div`
   position: absolute;
   bottom: ${calculateMinSizeBasedOnFigma(-12)};
   right: 0;
+  ${animation.secondShownChildren}
 `
 const StyledTextImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(569)};

--- a/src/components/ui/modal/MobileHPandMPVisualizationModal.tsx
+++ b/src/components/ui/modal/MobileHPandMPVisualizationModal.tsx
@@ -3,6 +3,7 @@ import { Modal } from 'components/ui/modal/Modal'
 import { ROOT_MARGIN } from 'consts/rootMargin'
 import { useInView } from 'react-intersection-observer'
 import { calculateMinSizeBasedOnFigma } from 'utils/figma/calculateSizeBasedOnFigma'
+import { animation } from 'styles/animation/modalAnimation'
 import styled from 'styled-components'
 
 type Props = {}
@@ -69,6 +70,7 @@ const StyledTitleImageContainer = styled.div`
   width: ${calculateMinSizeBasedOnFigma(1120)};
   margin: 0 auto;
   padding-bottom: 4px;
+  ${animation.firstShownChildren}
 `
 const StyledTitleImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(1120)};
@@ -76,15 +78,18 @@ const StyledTitleImage = styled.img`
 `
 const StyledInstalledUserImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(620)};
+  ${animation.secondShownChildren}
 `
 const StyledMindWaveImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(620)};
+  ${animation.secondShownChildren}
 `
 const StyledKurauchiImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(665)};
 `
 const StyledTextImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(542)};
+  ${animation.secondShownChildren}
 `
 const StyledEggContainer = styled.div`
   transform: translateY(-24%);
@@ -94,6 +99,7 @@ const StyledMindWaveContainer = styled.div`
 `
 const StyledEggImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(420)};
+  ${animation.secondShownChildren}
 `
 const StyledSolutionImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(350)};
@@ -106,4 +112,5 @@ const StyledRightContainer = styled.div`
   position: absolute;
   top: ${calculateMinSizeBasedOnFigma(332)};
   right: 0;
+  ${animation.secondShownChildren}
 `

--- a/src/components/ui/modal/MobileHPandMPVisualizationModal.tsx
+++ b/src/components/ui/modal/MobileHPandMPVisualizationModal.tsx
@@ -69,7 +69,7 @@ const StyledWrap = styled.div`
 const StyledTitleImageContainer = styled.div`
   width: ${calculateMinSizeBasedOnFigma(1120)};
   margin: 0 auto;
-  padding-bottom: 4px;
+  padding-bottom: ${calculateMinSizeBasedOnFigma(4)};
   ${animation.firstShownChildren}
 `
 const StyledTitleImage = styled.img`

--- a/src/components/ui/modal/MobileStatusVisualizationModal.tsx
+++ b/src/components/ui/modal/MobileStatusVisualizationModal.tsx
@@ -3,6 +3,7 @@ import { Modal } from 'components/ui/modal/Modal'
 import { ROOT_MARGIN } from 'consts/rootMargin'
 import { useInView } from 'react-intersection-observer'
 import { calculateMinSizeBasedOnFigma } from 'utils/figma/calculateSizeBasedOnFigma'
+import { animation } from 'styles/animation/modalAnimation'
 import styled from 'styled-components'
 
 type Props = {}
@@ -25,7 +26,7 @@ export const MobileStatusVisualizationModal: FCX<Props> = ({ className }) => {
               />
             </StyledTitleImageContainer>
             <div>
-              <StyledDragonImage src="/modal/mobile/status_mobile_hr.png" alt="hr" />
+              <StyledHumanResourcesPaperImage src="/modal/mobile/status_mobile_hr.png" alt="hr" />
             </div>
             <StyledRightContainer>
               <StyledClearContainer>
@@ -65,13 +66,15 @@ const StyledTitleImageContainer = styled.div`
   width: ${calculateMinSizeBasedOnFigma(1120)};
   margin: 0 auto;
   padding-bottom: 4px;
+  ${animation.firstShownChildren}
 `
 const StyledTitleImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(1120)};
   padding-bottom: ${calculateMinSizeBasedOnFigma(16)};
 `
-const StyledDragonImage = styled.img`
+const StyledHumanResourcesPaperImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(620)};
+  ${animation.secondShownChildren}
 `
 const StyledClearContainer = styled.div`
   padding-bottom: ${calculateMinSizeBasedOnFigma(30)};
@@ -83,6 +86,7 @@ const StyledTextImageContainer = styled.div`
   width: ${calculateMinSizeBasedOnFigma(1120)};
   transform: translateY(8%);
   margin: 0 auto;
+  ${animation.thirdShownChildren}
 `
 const StyledTextImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(1120)};
@@ -94,6 +98,7 @@ const StyledRightContainer = styled.div`
   position: absolute;
   top: ${calculateMinSizeBasedOnFigma(360)};
   right: 0;
+  ${animation.secondShownChildren}
 `
 
 const StyledStatusVideoContainer = styled.div`

--- a/src/components/ui/modal/MobileStatusVisualizationModal.tsx
+++ b/src/components/ui/modal/MobileStatusVisualizationModal.tsx
@@ -65,7 +65,7 @@ const StyledWrap = styled.div`
 const StyledTitleImageContainer = styled.div`
   width: ${calculateMinSizeBasedOnFigma(1120)};
   margin: 0 auto;
-  padding-bottom: 4px;
+  padding-bottom: ${calculateMinSizeBasedOnFigma(4)};
   ${animation.firstShownChildren}
 `
 const StyledTitleImage = styled.img`

--- a/src/components/ui/modal/MobileWorkVisualizationModal.tsx
+++ b/src/components/ui/modal/MobileWorkVisualizationModal.tsx
@@ -3,6 +3,7 @@ import { Modal } from 'components/ui/modal/Modal'
 import { ROOT_MARGIN } from 'consts/rootMargin'
 import { useInView } from 'react-intersection-observer'
 import { calculateMinSizeBasedOnFigma } from 'utils/figma/calculateSizeBasedOnFigma'
+import { animation } from 'styles/animation/modalAnimation'
 import styled from 'styled-components'
 
 type Props = {}
@@ -71,6 +72,7 @@ const StyledTitleImageContainer = styled.div`
   width: ${calculateMinSizeBasedOnFigma(1120)};
   margin: 0 auto;
   padding-bottom: 4px;
+  ${animation.firstShownChildren}
 `
 const StyledTitleImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(1120)};
@@ -78,11 +80,13 @@ const StyledTitleImage = styled.img`
 `
 const StyledWeaponImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(690)};
+  ${animation.secondShownChildren}
 `
 const StyledTextImageContainer = styled.div`
   width: ${calculateMinSizeBasedOnFigma(1120)};
   transform: translateY(28%);
   margin: 0 auto;
+  ${animation.thirdShownChildren}
 `
 const StyledTextImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(1120)};
@@ -105,6 +109,7 @@ const StyledMonsterVideoContainer = styled.div`
   justify-content: center;
   border-radius: ${calculateMinSizeBasedOnFigma(8)};
   border: solid ${calculateMinSizeBasedOnFigma(1)} ${({ theme }) => theme.COLORS.BORDER.MINE_SHAFT};
+  ${animation.secondShownChildren}
 
   video {
     width: ${calculateMinSizeBasedOnFigma(570)};
@@ -123,6 +128,7 @@ const StyledAttackVideoContainer = styled.div`
   justify-content: center;
   border-radius: ${calculateMinSizeBasedOnFigma(8)};
   border: solid ${calculateMinSizeBasedOnFigma(1)} ${({ theme }) => theme.COLORS.BORDER.MINE_SHAFT};
+  ${animation.secondShownChildren}
 
   video {
     width: ${calculateMinSizeBasedOnFigma(560)};

--- a/src/components/ui/modal/MobileWorkVisualizationModal.tsx
+++ b/src/components/ui/modal/MobileWorkVisualizationModal.tsx
@@ -71,7 +71,7 @@ const StyledWrap = styled.div`
 const StyledTitleImageContainer = styled.div`
   width: ${calculateMinSizeBasedOnFigma(1120)};
   margin: 0 auto;
-  padding-bottom: 4px;
+  padding-bottom: ${calculateMinSizeBasedOnFigma(4)};
   ${animation.firstShownChildren}
 `
 const StyledTitleImage = styled.img`

--- a/src/components/ui/modal/Modal.tsx
+++ b/src/components/ui/modal/Modal.tsx
@@ -41,9 +41,9 @@ const StyledWrapper = styled.div`
   padding: ${padding};
   z-index: ${({ theme }) => theme.Z_INDEX.MODAL};
   ${mediaQuery.sm`
-     width: 100%;
-     height: ${calculateMinSizeBasedOnFigma(1750)};
-     padding: ${mobilePadding};
+    width: 100%;
+    height: ${calculateMinSizeBasedOnFigma(1750)};
+    padding: ${mobilePadding};
   `}
 `
 const StyledNamePlate = styled.p`
@@ -74,9 +74,7 @@ const StyledNamePlate = styled.p`
     height: ${calculateMinSizeBasedOnFigma(140)};
   `}
 `
-const StyledChildrenWrapper = styled.div`
-  ${animation.children}
-`
+const StyledChildrenWrapper = styled.div``
 const StyledBackgroundWrapper = styled.div`
   z-index: ${({ theme }) => theme.Z_INDEX.INDEX_MINUS_2};
   position: absolute;

--- a/src/components/ui/modal/Modal.tsx
+++ b/src/components/ui/modal/Modal.tsx
@@ -69,7 +69,7 @@ const StyledNamePlate = styled.p`
     `}
   ${mediaQuery.sm`
     font-size: ${calculateMinSizeBasedOnFigma(60)};
-    top: calc(-35px / 2);
+    top: calc(${calculateMinSizeBasedOnFigma(-35)} / 2);
     width: ${calculateMinSizeBasedOnFigma(1120)};
     height: ${calculateMinSizeBasedOnFigma(140)};
   `}

--- a/src/components/ui/modal/StatusVisualizationModal.tsx
+++ b/src/components/ui/modal/StatusVisualizationModal.tsx
@@ -1,10 +1,11 @@
 import React, { FCX } from 'react'
 import { Modal } from 'components/ui/modal/Modal'
+import { Spacer } from 'components/ui/spacer/Spacer'
 import { ROOT_MARGIN } from 'consts/rootMargin'
 import { useInView } from 'react-intersection-observer'
 import { calculateMinSizeBasedOnFigma } from 'utils/figma/calculateSizeBasedOnFigma'
+import { animation } from 'styles/animation/modalAnimation'
 import styled from 'styled-components'
-import { Spacer } from '../spacer/Spacer'
 
 type Props = {}
 
@@ -20,7 +21,7 @@ export const StatusVisualizationModal: FCX<Props> = ({ className }) => {
         <Modal title="ステータスの見える化">
           <StyledWrap>
             <div>
-              <StyledHRImage src="/modal/hr.png" alt="hr" loading="lazy" />
+              <StyledHumanResourcesPaperImage src="/modal/hr.png" alt="hr" loading="lazy" />
             </div>
             <div>
               <div>
@@ -67,14 +68,17 @@ const StyledWrap = styled.div`
   gap: ${calculateMinSizeBasedOnFigma(30)};
   position: relative;
 `
-const StyledHRImage = styled.img`
+const StyledHumanResourcesPaperImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(325)};
+  ${animation.secondShownChildren}
 `
 const StyledStatusTitleImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(448)};
+  ${animation.firstShownChildren}
 `
 const StyledStatusTextImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(560)};
+  ${animation.secondShownChildren}
 `
 const StyledQuillContainer = styled.div`
   position: absolute;
@@ -83,6 +87,7 @@ const StyledQuillContainer = styled.div`
 `
 const StyledQuillImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(263)};
+  ${animation.firstShownChildren}
 `
 
 const StyledStatusVideoContainer = styled.div`
@@ -94,6 +99,7 @@ const StyledStatusVideoContainer = styled.div`
   justify-content: center;
   border-radius: ${calculateMinSizeBasedOnFigma(4)};
   border: solid ${calculateMinSizeBasedOnFigma(1)} ${({ theme }) => theme.COLORS.BORDER.MINE_SHAFT};
+  ${animation.firstShownChildren}
 
   video {
     width: ${calculateMinSizeBasedOnFigma(582)};

--- a/src/components/ui/modal/WorkVisualizationModal.tsx
+++ b/src/components/ui/modal/WorkVisualizationModal.tsx
@@ -78,6 +78,7 @@ const StyledFlexContainer = styled.div`
 `
 const StyledTitleImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(677)};
+  ${animation.firstShownChildren}
 `
 const StyledWeaponImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(332)};

--- a/src/components/ui/modal/WorkVisualizationModal.tsx
+++ b/src/components/ui/modal/WorkVisualizationModal.tsx
@@ -3,8 +3,9 @@ import { Modal } from 'components/ui/modal/Modal'
 import { ROOT_MARGIN } from 'consts/rootMargin'
 import { useInView } from 'react-intersection-observer'
 import { calculateMinSizeBasedOnFigma } from 'utils/figma/calculateSizeBasedOnFigma'
+import { Spacer } from 'components/ui/spacer/Spacer'
+import { animation } from 'styles/animation/modalAnimation'
 import styled from 'styled-components'
-import { Spacer } from '../spacer/Spacer'
 
 type Props = {}
 
@@ -80,6 +81,7 @@ const StyledTitleImage = styled.img`
 `
 const StyledWeaponImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(332)};
+  ${animation.firstShownChildren}
 `
 const StyledWeaponContainer = styled.div`
   transform: translateY(20%);
@@ -91,6 +93,7 @@ const StyledTextImageContainer = styled.div`
   position: absolute;
   top: 0;
   right: ${calculateMinSizeBasedOnFigma(200)};
+  ${animation.secondShownChildren}
 `
 const StyledTextImage = styled.img`
   width: ${calculateMinSizeBasedOnFigma(491)};
@@ -105,6 +108,7 @@ const StyledMonsterVideoContainer = styled.div`
   justify-content: center;
   border-radius: ${calculateMinSizeBasedOnFigma(4)};
   border: solid ${calculateMinSizeBasedOnFigma(1)} ${({ theme }) => theme.COLORS.BORDER.MINE_SHAFT};
+  ${animation.firstShownChildren}
 
   video {
     width: ${calculateMinSizeBasedOnFigma(245)};
@@ -123,6 +127,7 @@ const StyledAttackVideoContainer = styled.div`
   justify-content: center;
   border-radius: ${calculateMinSizeBasedOnFigma(4)};
   border: solid ${calculateMinSizeBasedOnFigma(1)} ${({ theme }) => theme.COLORS.BORDER.MINE_SHAFT};
+  ${animation.secondShownChildren}
 
   video {
     width: ${calculateMinSizeBasedOnFigma(334)};

--- a/src/components/ui/videoArea/MobileVideoArea.tsx
+++ b/src/components/ui/videoArea/MobileVideoArea.tsx
@@ -38,7 +38,6 @@ const StyledContainer = styled.div`
   position: relative;
   width: 100%;
   height: ${calculateVwBasedOnFigma(2300)};
-  padding: 56px 14px;
   padding: ${calculateVwBasedOnFigma(190)} ${calculateVwBasedOnFigma(60)};
   background: url('/background/mb_brown_bg.png') center center;
   background-repeat: no-repeat;

--- a/src/styles/animation/modalAnimation.ts
+++ b/src/styles/animation/modalAnimation.ts
@@ -72,10 +72,19 @@ export const animation = {
     animation: ${closeButtonKeyframes} 0.25s both ease;
     will-change: animation, opacity;
   `,
-  children: css`
+  firstShownChildren: css`
     animation: ${childrenKeyframes} 0.3s 0.6s both linear;
     will-change: animation, opacity, transform;
   `,
+  secondShownChildren: css`
+    animation: ${childrenKeyframes} 0.3s 1.2s both linear;
+    will-change: animation, opacity, transform;
+  `,
+  // TODO: 使う機会がなかったら消す
+  // thirdShownChildren: css`
+  //   animation: ${childrenKeyframes} 0.3s 1.8s both linear;
+  //   will-change: animation, opacity, transform;
+  // `,
   bgLeft: css`
     animation: ${bgLeftKeyframes} 0.25s 0.15s both ease;
     will-change: animation, background-position;

--- a/src/styles/animation/modalAnimation.ts
+++ b/src/styles/animation/modalAnimation.ts
@@ -80,11 +80,10 @@ export const animation = {
     animation: ${childrenKeyframes} 0.3s 1.2s both linear;
     will-change: animation, opacity, transform;
   `,
-  // TODO: 使う機会がなかったら消す
-  // thirdShownChildren: css`
-  //   animation: ${childrenKeyframes} 0.3s 1.8s both linear;
-  //   will-change: animation, opacity, transform;
-  // `,
+  thirdShownChildren: css`
+    animation: ${childrenKeyframes} 0.3s 1.8s both linear;
+    will-change: animation, opacity, transform;
+  `,
   bgLeft: css`
     animation: ${bgLeftKeyframes} 0.25s 0.15s both ease;
     will-change: animation, background-position;

--- a/src/utils/figma/calculateSizeBasedOnFigma.ts
+++ b/src/utils/figma/calculateSizeBasedOnFigma.ts
@@ -2,6 +2,8 @@ type pxStr = `${number}px`
 
 const FIGMA_WIDTH_PX = 1440
 const FIGMA_HEIGHT_PX = 900
+const FIGMA_SM_WIDTH_PX = 414
+const FIGMA_SM_HEIGHT_PX = 896
 
 /**
  * Figma の画面設計で指定されている px を、画面設計上の画面サイズ準拠で vw, vh に変換し、
@@ -13,6 +15,20 @@ export const calculateMinSizeBasedOnFigma = (px: number | pxStr): string => {
   const numPx = typeof px === 'string' ? Number(px.replace('px', '')) : px
   const vw = `${(numPx / FIGMA_WIDTH_PX) * 100}vw`
   const vh = `${(numPx / FIGMA_HEIGHT_PX) * 100}vh`
+
+  return `${numPx > 0 ? 'min' : 'max'}(${numPx}px, ${vw}, ${vh})`
+}
+
+/**
+ * Figma のスマホサイズの画面設計で指定されている px を、画面設計上の画面サイズ準拠で vw, vh に変換し、
+ * 指定したピクセル数, vw, vh で一番小さい値が適用されるように css の min 関数を返却する
+ * @param {number | pxStr} px - number | '${number}px'
+ * @returns {string}
+ */
+export const calculateSmMinSizeBasedOnFigma = (px: number | pxStr): string => {
+  const numPx = typeof px === 'string' ? Number(px.replace('px', '')) : px
+  const vw = `${(numPx / FIGMA_SM_WIDTH_PX) * 100}vw`
+  const vh = `${(numPx / FIGMA_SM_HEIGHT_PX) * 100}vh`
 
   return `${numPx > 0 ? 'min' : 'max'}(${numPx}px, ${vw}, ${vh})`
 }


### PR DESCRIPTION
## 実装の概要
- 特徴セクションの文字にアニメーションを付与
  - 時間差で2~3回に分けて文字/画像が表示されるようにした

<!-- 概要を入力 -->

Closes #18 <!-- issueをcloseさせたい & trelloのタスクを完了に移動したい場合 -->

動画だと仕事の見える化セクション内の文字が一部アニメーションかかっていないが、既に修正済みです

https://user-images.githubusercontent.com/47961006/148632798-3b4b2e78-c931-4124-9e68-374665a16f43.mov

https://user-images.githubusercontent.com/47961006/148632818-bee6cd92-e37f-4674-94a5-8ea5e889e9f2.mov

## 目的
特徴セクションの文字のアニメーションを付与

## レビューして欲しいところ

## 不安に思っていること

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク
#32

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
